### PR TITLE
Add support for cron timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Creates a new bossbat instance. All arguments are optional.
 - `options.connection`: Used to configure the connection to your redis. This accepts the same arguments that [`ioredis`](https://github.com/luin/ioredis/blob/master/API.md#new_Redis_new) does.
 - `options.prefix`: A string that all redis keys will be prefixed with. Defaults to `bossbat`.
 - `options.ttl`: The number of milliseconds before a job times out. Setting it will change the maximum duration that jobs can hold a lock. By default, job locks will timeout if a job does not complete in 2000ms.
+- `options.tz`: An optional timezone used with `jobDefinition.cron` expressions.
 
 #### `bossbat.hire(jobName: String, jobDefinition: Object)`
 

--- a/src/Bossbat.js
+++ b/src/Bossbat.js
@@ -9,11 +9,12 @@ const JOB_TTL = 2000;
 const JOB_PREFIX = 'bossbat';
 
 export default class Bossbat {
-  constructor({ connection, prefix = JOB_PREFIX, ttl = JOB_TTL } = {}) {
+  constructor({ connection, prefix = JOB_PREFIX, ttl = JOB_TTL, tz } = {}) {
     const DB_NUMBER = (connection && connection.db) || 0;
 
     this.prefix = prefix;
     this.ttl = ttl;
+    this.tz = tz;
 
     this.client = new Redis(connection);
     this.subscriber = new Redis(connection);
@@ -127,7 +128,8 @@ export default class Bossbat {
         throw new Error(`Unknown interval of type "${typeOfEvery}" passed to hire.`);
       }
     } else if (definition.cron) {
-      const nextTime = parseExpression(definition.cron, { iterator: false }).next().getTime();
+      const options = { iterator: false, tz: this.tz };
+      const nextTime = parseExpression(definition.cron, options).next().getTime();
       const cronTimeout = nextTime - Date.now();
       // Force timeout to be at least 1:
       timeout = cronTimeout >= 1 ? cronTimeout : 1;

--- a/src/__tests__/Bossbat.test.js
+++ b/src/__tests__/Bossbat.test.js
@@ -11,10 +11,11 @@ describe('Bossbat Units', () => {
   });
 
   it('constructs with arguments', () => {
-    const boss = new Bossbat({ connection: { db: 4 }, ttl: 101, prefix: 'p' });
+    const boss = new Bossbat({ connection: { db: 4 }, ttl: 101, prefix: 'p', tz: 'Europe/Helsinki' });
     expect(boss).toBeInstanceOf(Bossbat);
     expect(boss.ttl).toEqual(101);
     expect(boss.prefix).toEqual('p');
+    expect(boss.tz).toEqual('Europe/Helsinki');
     boss.quit();
   });
 


### PR DESCRIPTION
Add `options.tz` parameter for setting timezone in cron expressions.