### PR TITLE
Fix cron timeout

### DIFF
--- a/src/Bossbat.js
+++ b/src/Bossbat.js
@@ -129,10 +129,9 @@ export default class Bossbat {
       }
     } else if (definition.cron) {
       const options = { iterator: false, tz: this.tz };
-      const nextTime = parseExpression(definition.cron, options).next().getTime();
-      const cronTimeout = nextTime - Date.now();
-      // Force timeout to be at least 1:
-      timeout = cronTimeout >= 1 ? cronTimeout : 1;
+      const iterator = parseExpression(definition.cron, options);
+      const cronTimeout = iterator.next().getTime() - Date.now();
+      timeout = cronTimeout > 0 ? cronTimeout : iterator.next().getTime() - Date.now();
     }
     return this.client.set(this.getJobKey(name), name, 'PX', timeout, 'NX');
   }

--- a/src/Bossbat.js
+++ b/src/Bossbat.js
@@ -130,8 +130,9 @@ export default class Bossbat {
     } else if (definition.cron) {
       const options = { iterator: false, tz: this.tz };
       const iterator = parseExpression(definition.cron, options);
-      const cronTimeout = iterator.next().getTime() - Date.now();
-      timeout = cronTimeout > 0 ? cronTimeout : iterator.next().getTime() - Date.now();
+      const nextCronTimeout = () => iterator.next().getTime() - Date.now();
+      const cronTimeout = nextCronTimeout();
+      timeout = cronTimeout > 0 ? cronTimeout : nextCronTimeout();
     }
     return this.client.set(this.getJobKey(name), name, 'PX', timeout, 'NX');
   }


### PR DESCRIPTION
Closes #8.

If `cronTimeout` is `0` or negative, the runner has already been invoked. Instead of setting `cronTimeout` to `1` (one millisecond) we should get the next time from the iterator.
