### PR TITLE
Add parameter for disabling redis config call

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Creates a new bossbat instance. All arguments are optional.
 - `options.prefix`: A string that all redis keys will be prefixed with. Defaults to `bossbat`.
 - `options.ttl`: The number of milliseconds before a job times out. Setting it will change the maximum duration that jobs can hold a lock. By default, job locks will timeout if a job does not complete in 2000ms.
 - `options.tz`: An optional timezone used with `jobDefinition.cron` expressions.
+- `options.disableRedisConfig`: Disable usage of the redis `CONFIG` command,
+as it might be disabled in certain redis configurations. NOTE: If this option
+is used, the redis configuration should contain `notify-keyspace-events Ex`
 
 #### `bossbat.hire(jobName: String, jobDefinition: Object)`
 

--- a/src/Bossbat.js
+++ b/src/Bossbat.js
@@ -9,7 +9,7 @@ const JOB_TTL = 2000;
 const JOB_PREFIX = 'bossbat';
 
 export default class Bossbat {
-  constructor({ connection, prefix = JOB_PREFIX, ttl = JOB_TTL, tz } = {}) {
+  constructor({ connection, prefix = JOB_PREFIX, ttl = JOB_TTL, tz, disableRedisConfig } = {}) {
     const DB_NUMBER = (connection && connection.db) || 0;
 
     this.prefix = prefix;
@@ -23,7 +23,9 @@ export default class Bossbat {
     this.jobs = {};
     this.qas = [];
 
-    this.subscriber.config('SET', 'notify-keyspace-events', 'Ex');
+    if (!disableRedisConfig) {
+      this.subscriber.config('SET', 'notify-keyspace-events', 'Ex');
+    }
 
     // Subscribe to expiring keys on the jobs DB:
     this.subscriber.subscribe(`__keyevent@${DB_NUMBER}__:expired`);

--- a/src/__tests__/Bossbat.test.js
+++ b/src/__tests__/Bossbat.test.js
@@ -2,20 +2,40 @@
 /* eslint-disable global-require */
 
 describe('Bossbat Units', () => {
-  const Bossbat = require('../Bossbat');
+  let Bossbat;
+  let Redis;
+
+  beforeAll(() => {
+    jest.mock('ioredis');
+    Bossbat = require('../Bossbat');
+    Redis = require('ioredis');
+  });
+
+  afterAll(() => {
+    jest.resetModules();
+    jest.unmock('ioredis');
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
 
   it('constructs with no arguments', () => {
     const boss = new Bossbat();
     expect(boss).toBeInstanceOf(Bossbat);
+    expect(Redis.mock.instances.length).toEqual(2);
+    expect(Redis.mock.instances[1].config.mock.calls.length).toEqual(1);
     boss.quit();
   });
 
   it('constructs with arguments', () => {
-    const boss = new Bossbat({ connection: { db: 4 }, ttl: 101, prefix: 'p', tz: 'Europe/Helsinki' });
+    const boss = new Bossbat({ connection: { db: 4 }, ttl: 101, prefix: 'p', tz: 'Europe/Helsinki', disableRedisConfig: true });
     expect(boss).toBeInstanceOf(Bossbat);
     expect(boss.ttl).toEqual(101);
     expect(boss.prefix).toEqual('p');
     expect(boss.tz).toEqual('Europe/Helsinki');
+    expect(Redis.mock.instances.length).toEqual(2);
+    expect(Redis.mock.instances[1].config.mock.calls.length).toEqual(0);
     boss.quit();
   });
 


### PR DESCRIPTION
Some redis configurations don't allow clients to use the config command,
resulting in an unhandled rejection.