### PR TITLE
Pass job name into the work handler in order to provide context for the job

### DIFF
--- a/src/Bossbat.js
+++ b/src/Bossbat.js
@@ -98,7 +98,7 @@ export default class Bossbat {
       // Call the QA functions, then finally the job function. We use a copy of
       // the job definition to prevent pollution between scheduled runs.
       const response = fn(name, { ...this.jobs[name] }, (_, definition) => (
-        definition.work()
+        definition.work(name)
       ));
 
       const end = () => { lock.unlock(); };

--- a/src/__tests__/Bossbat.test.js
+++ b/src/__tests__/Bossbat.test.js
@@ -84,7 +84,8 @@ describe('Bossbat Integration', () => {
   it('runs scheduled work', (done) => {
     boss.hire('scheduled', {
       every: '200 ms',
-      work: () => {
+      work: (jobName) => {
+        expect(jobName).toEqual('scheduled');
         done();
       },
     });


### PR DESCRIPTION
The job name could be used as a cache key to look up further contextual data